### PR TITLE
Allow notifier to specify an alternative category

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "TimedNotify",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "url": "https://www.mediawiki.org/wiki/Extension:TimedNotify",
   "type": "other",
   "author": [

--- a/src/MediaWiki/Hooks/EchoHooks.php
+++ b/src/MediaWiki/Hooks/EchoHooks.php
@@ -45,11 +45,11 @@ class EchoHooks {
 	 */
 	private static function createDefinition( Notifier $notifier ): array {
 		$definition = [
-			'category' => 'timednotify-time-based-notification',
 			'section' => 'alert',
 			'group' => 'neutral'
 		];
 
+        $definition['category'] = $notifier->getCategory();
 		$definition['presentation-model'] = $notifier->getPresentationModel();
 		$definition['user-locators'] = [ get_class( $notifier ) . '::getNotificationUsers' ];
 		$definition['user-filters'] = [ get_class( $notifier ) . '::getFilteredUsers' ];

--- a/src/MediaWiki/Hooks/EchoHooks.php
+++ b/src/MediaWiki/Hooks/EchoHooks.php
@@ -49,7 +49,7 @@ class EchoHooks {
 			'group' => 'neutral'
 		];
 
-        $definition['category'] = $notifier->getCategory();
+		$definition['category'] = $notifier->getCategory();
 		$definition['presentation-model'] = $notifier->getPresentationModel();
 		$definition['user-locators'] = [ get_class( $notifier ) . '::getNotificationUsers' ];
 		$definition['user-filters'] = [ get_class( $notifier ) . '::getFilteredUsers' ];

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -46,14 +46,14 @@ abstract class Notifier {
 	 */
 	abstract public static function getNotificationUsers( EchoEvent $event ): array;
 
-    /**
-     * Returns the category of this notification.
-     *
-     * @return string
-     */
-    public function getCategory(): string {
-        return 'timednotify-time-based-notification';
-    }
+	/**
+	 * Returns the category of this notification.
+	 *
+	 * @return string
+	 */
+	public function getCategory(): string {
+		return 'timednotify-time-based-notification';
+	}
 
 	/**
 	 * Returns additional icons to define.

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -46,6 +46,15 @@ abstract class Notifier {
 	 */
 	abstract public static function getNotificationUsers( EchoEvent $event ): array;
 
+    /**
+     * Returns the category of this notification.
+     *
+     * @return string
+     */
+    public function getCategory(): string {
+        return 'timednotify-time-based-notification';
+    }
+
 	/**
 	 * Returns additional icons to define.
 	 *


### PR DESCRIPTION
This pull request adds an option for a notifier to specify an alternative category in which the notifier should live. The extension defining the notifier is responsible for creating the category in case an alternative category is used. This change is backwards-compatible with existing notifiers.